### PR TITLE
Refactoring connectome.py

### DIFF
--- a/connectome.py
+++ b/connectome.py
@@ -13,9 +13,15 @@
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('-d','--disembodied', help='Run without sensor data', action='store_true')
+parser.add_argument('-v', '--verbose', action='count', default=0)
+# three levels of verbosity: [], -v, -vv
+# 0: only print starting and exiting messages
+# 1: print only when obstacles/food found
+# 2: print speed, left and right every time
 disembodied = parser.parse_args().disembodied
+verbosity = parser.parse_args().verbose
 
-print disembodied
+print "Running on Robot: " + str(not disembodied)
 
 if not disembodied:
         from gopigo import fwd, bwd, left_rot, right_rot, stop, set_speed, us_dist, volt
@@ -83,7 +89,6 @@ def ADAL():
         postSynaptic['RIML'][nextState] += 3
         postSynaptic['RIPL'][nextState] += 1
         postSynaptic['SMDVR'][nextState] += 2
-        print (nextState)
 
 def ADAR():
         postSynaptic['ADAL'][nextState] += 1
@@ -166,7 +171,6 @@ def ADFL():
         postSynaptic['RIGL'][nextState] += 1
         postSynaptic['RIR'][nextState] += 2
         postSynaptic['SMBVL'][nextState] += 2
-        #print (postSynaptic['ADAL'][nextState])
 
 def ADFR():
         postSynaptic['ADAR'][nextState] += 2
@@ -4827,7 +4831,8 @@ def motorcontrol():
                 new_speed = 150
         elif new_speed < 75:
                 new_speed = 75
-        print "Left: ", accumleft, "Right:", accumright, "Speed: ", new_speed
+        if verbosity > 1:
+                print "Left: ", accumleft, "Right:", accumright, "Speed: ", new_speed
         
         if not disembodied:
                 set_speed(new_speed)
@@ -4938,7 +4943,8 @@ def main():
                 # Do we need to switch states at the end of each loop? No, this is done inside the runconnectome()
                 # function, called inside each loop.
                 if dist>0 and dist<30:
-                        print "OBSTACLE (Nose Touch)", dist 
+                        if verbosity > 0:
+                                print "OBSTACLE (Nose Touch)", dist 
                         dendriteAccumulate("FLPR")
                         dendriteAccumulate("FLPL")
                         dendriteAccumulate("ASHL")
@@ -4952,7 +4958,8 @@ def main():
                         runconnectome()
                 else:
                         if tfood < 2:
-                                print "FOOD"
+                                if verbosity > 0:
+                                        print "FOOD"
                                 dendriteAccumulate("ADFL")
                                 dendriteAccumulate("ADFR")
                                 dendriteAccumulate("ASGR")

--- a/connectome.py
+++ b/connectome.py
@@ -15,11 +15,15 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-d','--disembodied', help='Run without sensor data', action='store_true')
 disembodied = parser.parse_args().disembodied
 
+print disembodied
+
 if not disembodied:
         from gopigo import fwd, bwd, left_rot, right_rot, stop, set_speed, us_dist, volt
 
 import time
 import copy
+import signal
+import sys
 
 # The postSynaptic dictionary contains the accumulated weighted values as the
 # connectome is executed
@@ -4910,18 +4914,19 @@ def runconnectome():
 createpostSynaptic()
 
 dist=0
-set_speed(120)
 
-print "Voltage: ", volt()
+if not disembodied:
+        set_speed(120)
+        print "Voltage: ", volt()
 
 tfood = 0
 
-try:
+def main():
         """Here is where you would put in a method to stimulate the neurons
         We stimulate chemosensory neurons constantly unless nose touch
         (sonar) is stimulated and then we fire nose touch neurites.
         """
-### Use CNTRL-C to stop the program
+
         while True:
                 if not disembodied:
                         dist = us_dist(15)
@@ -4962,10 +4967,19 @@ try:
                         if (tfood > 20):
                                 tfood = 0
 
-except KeyboardInterrupt:
+def keyboard_interrupt_handler(a, b):
+        """Use CNTRL-C to stop the program."""
+
         if not disembodied:
                 stop()
 
         print "Ctrl+C detected. Program Stopped!"
         for pscheck in postSynaptic:
                 print (pscheck,' ',postSynaptic[pscheck][0],' ',postSynaptic[pscheck][1])
+
+        sys.exit(0)
+
+if __name__ == '__main__':
+        signal.signal(signal.SIGINT, keyboard_interrupt_handler)
+        main()
+


### PR DESCRIPTION
# Refactoring connectome.py
The goal of the changes in this file is to eliminate the unecessary code duplication in this repository. 
## Specific changes
- Combined the functionality of `disembodiedConnectome.py` and `connectome.py` in one file: you can run the latter with command line flag that specifies whether or not it is running on the robot or not. 
- Cleared up formatting of comments/indents in `connectome.py`; it is now more manageable than 

## How this helps
- All the files except for `connectome.py` can be removed from master branch. 
 - `GoPiGoConnectome.py` seems to be obsolete because it is several commits behind `connectome.py`. Its comments are harder to read, its code is poorer structured, and if anything is necessary to be used from there for reference, then it is in the commit history.
 - Files with Experimental optimizations that failed to make the process faster because of the limitations of CPython seem to belong in other branches, while master should contain only `connectome.py` now.

## Other Changes
- Fixed indentation to be consistent
- Code is more idiomatically python, and can be more easily adapted to a prototype that interacts with an external API
- Is more user friendly and efficient when it optionally prints out everything in memory as a `.__str__()` (string).

## How this ultimately allows for this codebase to move forward
- We can now break this up into modules and modular pieces and not create a terrible mess with a confusing file/folder structure.
 - This makes it possible to add web-communication features to it.